### PR TITLE
Reodering of mouse.toggle()

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,8 +500,8 @@ toggleAsync(state: boolean, button?: mouseButton, delay?: number | randomFromRan
 Switch mouse button state.
 | Argument | Description | Default Value |
 | --- | --- | --- |
-| state | key state selection: **true** for press, **false** for release | true |
 | button | name of mouse button | "left" |
+| state | key state selection: **true** for press, **false** for release | true |
 | delay | milliseconds to sleep/await after switching mouse button state | [buttonTogglerDelay](#buttontogglerdelay) |
 
 ```js

--- a/src/js/mouse.js
+++ b/src/js/mouse.js
@@ -148,8 +148,8 @@ module.exports.Mouse = (ClassName) =>
             return self._getPos();
           },
           toggle(
-            isButtonDown,
             button = "left",
+            isButtonDown,
             buttonTogglerDelay = _this.buttonTogglerDelay
           ) {
             _this.emit("before-toggle", ...arguments);
@@ -158,8 +158,8 @@ module.exports.Mouse = (ClassName) =>
             _this.emit("after-toggle", ...arguments);
           },
           async toggleAsync(
-            isButtonDown,
             button = "left",
+            isButtonDown,
             buttonTogglerDelay = _this.buttonTogglerDelay
           ) {
             _this.emit("before-toggle", ...arguments);


### PR DESCRIPTION
I reorderer mouse.toggle() so the arguments matches the order of keyboard.toggle(). The readme was updated accordingly.