### PR TITLE
Support sending numeric scancodes

### DIFF
--- a/src/addon/keyboard.cpp
+++ b/src/addon/keyboard.cpp
@@ -3,11 +3,11 @@
 #include "helper.hpp"
 
 void Keyboard::toggleKey(const Napi::CallbackInfo &info) {
-  if (info[0].IsNumber())
-    keyToggler(info[0].As<Napi::Number>(), info[1].As<Napi::Boolean>());
-  else
-    keyToggler(Helper::keyboardButtons.at(info[0].As<Napi::String>()),
-               info[1].As<Napi::Boolean>());
+  UINT code = info[0].IsNumber()
+                  ? info[0].As<Napi::Number>()
+                  : Helper::keyboardButtons.at(info[0].As<Napi::String>());
+
+  keyToggler(code, info[1].As<Napi::Boolean>());
 }
 
 void Keyboard::printChar(const Napi::CallbackInfo &info) {

--- a/src/addon/keyboard.cpp
+++ b/src/addon/keyboard.cpp
@@ -3,7 +3,11 @@
 #include "helper.hpp"
 
 void Keyboard::toggleKey(const Napi::CallbackInfo &info) {
-  keyToggler(Helper::keyboardButtons.at(info[0].As<Napi::String>()), info[1].As<Napi::Boolean>());
+  if (info[0].IsNumber())
+    keyToggler(info[0].As<Napi::Number>(), info[1].As<Napi::Boolean>());
+  else
+    keyToggler(Helper::keyboardButtons.at(info[0].As<Napi::String>()),
+               info[1].As<Napi::Boolean>());
 }
 
 void Keyboard::printChar(const Napi::CallbackInfo &info) {


### PR DESCRIPTION
The `KeyboardButton` type allows one to send VK_* codes, but this function was crashing when getting non-strings.  This fixes that.

Really killer library by the way.  I'm using it to create something similar to Logitech's now-defunct LGS software, for qmk-firmware keyboards!